### PR TITLE
Fix NavigationBar and TabBar covering TableView and ScrollView

### DIFF
--- a/src/main/kotlin/sessiondetail/SessionDetailViewController.kt
+++ b/src/main/kotlin/sessiondetail/SessionDetailViewController.kt
@@ -3,6 +3,7 @@ package sessiondetail
 import kotlinx.cinterop.ExportObjCClass
 import kotlinx.cinterop.ObjCOutlet
 import kotlinx.cinterop.initBy
+import platform.CoreGraphics.CGRectGetHeight
 import platform.Foundation.NSCoder
 import platform.UIKit.*
 
@@ -23,6 +24,11 @@ class SessionDetailViewController(aDecoder: NSCoder) : UIViewController(aDecoder
         super.viewDidLoad()
 
         // FIXME: It's not elegant.
-        containerScroll.contentInset = UIEdgeInsetsMake(64.0 /* = Status bar height + Navigation bar height  */, 0.0, 0.0, 0.0)
+        containerScroll.contentInset = UIEdgeInsetsMake(
+                top = 64.0 /* = Status bar height + Navigation bar height  */,
+                left = 0.0,
+                bottom = tabBarController?.let { CGRectGetHeight(it.tabBar.frame) } ?: 0.0,
+                right = 0.0
+        )
     }
 }

--- a/src/main/kotlin/sessionslist/SessionsListViewController.kt
+++ b/src/main/kotlin/sessionslist/SessionsListViewController.kt
@@ -4,10 +4,9 @@ import kotlinx.cinterop.ExportObjCClass
 import kotlinx.cinterop.ObjCOutlet
 import kotlinx.cinterop.initBy
 import network.getSessions
+import platform.CoreGraphics.CGRectGetHeight
 import platform.Foundation.NSCoder
-import platform.UIKit.UIEdgeInsetsMake
-import platform.UIKit.UITableView
-import platform.UIKit.UIViewController
+import platform.UIKit.*
 
 @ExportObjCClass
 class SessionsListViewController(aDecoder: NSCoder) : UIViewController(aDecoder) {
@@ -18,7 +17,12 @@ class SessionsListViewController(aDecoder: NSCoder) : UIViewController(aDecoder)
     override fun viewDidLoad() {
         super.viewDidLoad()
         // FIXME: It's not elegant.
-        sessionsTable.contentInset = UIEdgeInsetsMake(64.0 /* = Status bar height + Navigation bar height  */, 0.0, 0.0, 0.0)
+        sessionsTable.contentInset = UIEdgeInsetsMake(
+                top = 64.0 /* = Status bar height + Navigation bar height  */,
+                left = 0.0,
+                bottom = tabBarController?.let { CGRectGetHeight(it.tabBar.frame) } ?: 0.0,
+                right = 0.0
+        )
 
         getSessions({ sessions, _, _, _ ->
             sessionsTable.dataSource = SessionsListDataSource(sessions!!)


### PR DESCRIPTION
## Overview (Required)
- NavigationBar and TabBar covres TableView and ScrollView.
    - On TableView, first cell and last cell is hidden by theses.
- Put inset and uncover tables.

## Links
-

## Screenshot

Bottom of Session list

Before | After
:--: | :--:
<img width="320" alt="before" src="https://user-images.githubusercontent.com/600512/35091670-8ad21aa4-fc80-11e7-891d-9fa2dc085cab.png"> | <img width="320" alt="after" src="https://user-images.githubusercontent.com/600512/35091614-60a312e2-fc80-11e7-8612-2180bbe5f097.png">
