### PR TITLE
Add pre-defined fixed sessions data.

### DIFF
--- a/src/main/kotlin/entity/Session.kt
+++ b/src/main/kotlin/entity/Session.kt
@@ -28,7 +28,7 @@ sealed class Session(
             override var dayNumber: Int,
             override var startTime: Date,
             override var endTime: Date,
-            var title: Int,
+            var title: String,
             var room: Room?
     ) : Session(id, dayNumber, startTime, endTime)
 

--- a/src/main/kotlin/fixeddata/SpecialSessions.kt
+++ b/src/main/kotlin/fixeddata/SpecialSessions.kt
@@ -1,0 +1,48 @@
+package fixeddata
+
+import entity.Room
+import entity.Session
+import network.parsing.parseISO8601Date
+
+class SpecialSessions {
+    companion object {
+        fun getSessions(): List<Session.SpecialSession> {
+            var index = 0
+            val specialSessionRoom = Room(513, "Hall")
+            return listOf(
+                    Session.SpecialSession(
+                            "100000" + index++,
+                            1,
+                            parseISO8601Date("2018-02-08T10:00:00"),
+                            parseISO8601Date("2018-02-08T10:20:00"),
+                            "Welcome talk",
+                            specialSessionRoom
+                    ),
+                    Session.SpecialSession(
+                            "100000" + index++,
+                            1,
+                            parseISO8601Date("2018-02-08T11:50:00"),
+                            parseISO8601Date("2018-02-08T12:50:00"),
+                            "Lunch",
+                            null
+                    ),
+                    Session.SpecialSession(
+                            "100000" + index++,
+                            1,
+                            parseISO8601Date("2018-02-08T17:40:00"),
+                            parseISO8601Date("2018-02-08T19:40:00"),
+                            "Party",
+                            specialSessionRoom
+                    ),
+
+                    Session.SpecialSession(
+                            "100000" + index,
+                            2,
+                            parseISO8601Date("2018-02-09T11:50:00"),
+                            parseISO8601Date("2018-02-09T12:50:00"),
+                            "Lunch",
+                            null
+                    ))
+        }
+    }
+}

--- a/src/main/kotlin/network/parsing/SessionParser.kt
+++ b/src/main/kotlin/network/parsing/SessionParser.kt
@@ -10,7 +10,7 @@ import network.Category
 import network.CategoryItem
 import platform.Foundation.*
 
-private fun parseISO8601Date(raw: String): Date {
+fun parseISO8601Date(raw: String): Date {
     val nsDate = NSDateFormatter().apply {
         dateFormat = "YYYY-MM-dd'T'HH:mm:ss"
         calendar = NSCalendar.currentCalendar

--- a/src/main/kotlin/sessiondetail/SessionDetailViewController.kt
+++ b/src/main/kotlin/sessiondetail/SessionDetailViewController.kt
@@ -47,11 +47,11 @@ class SessionDetailViewController(aDecoder: NSCoder) : UIViewController(aDecoder
                 descriptionText.text = session.desc
             }
             is Session.SpecialSession -> {
-                // TODO: We need String title.
-//                titleLabel.text = session.title
+                titleLabel.text = session.title
                 timeLabel.text = "DAY${session.dayNumber} / ${session.startTime.toReadableTimeString()} - ${session.endTime.toReadableTimeString()}"
                 placeLabel.text = session.room?.name ?: ""
-                // TODO: Hide speakers area.
+                // TODO: Hide speakers area and description area.
+                descriptionText.text = ""
             }
         }
     }

--- a/src/main/kotlin/sessionslist/SessionsListViewController.kt
+++ b/src/main/kotlin/sessionslist/SessionsListViewController.kt
@@ -1,5 +1,6 @@
 package sessionslist
 
+import fixeddata.SpecialSessions
 import kotlinx.cinterop.*
 import network.getSessions
 import platform.CoreGraphics.CGRectGetHeight
@@ -26,8 +27,9 @@ class SessionsListViewController(aDecoder: NSCoder) : UIViewController(aDecoder)
         )
         sessionsTable.delegate = sessionsListDelegate
 
-        getSessions({ sessions, _, _, _ ->
-            sessionsTable.dataSource = SessionsListDataSource(sessions!!)
+        getSessions({ speakerSessions, _, _, _ ->
+            val allSession = (speakerSessions!! + SpecialSessions.getSessions()).sortedBy { it.startTime.getTime().toLong() }
+            sessionsTable.dataSource = SessionsListDataSource(allSession)
             sessionsTable.reloadData()
         }, { error ->
             println(error)


### PR DESCRIPTION
## Issue
- close #2  , #20 

## Overview (Required)
- Pre-defined Special Sessions were missing such as "Welcome Talk".
- Add definitions of Special Session, and mix in Speaker Session list and make all sessions list.

## Links
- https://github.com/DroidKaigi/conference-app-2018/blob/master/app/src/main/java/io/github/droidkaigi/confsched2018/data/db/fixeddata/SpecialSessions.kt

## Screenshot
Before | After
:--: | :--:
![img_0107](https://user-images.githubusercontent.com/600512/35325906-77933c18-0138-11e8-93eb-d1229a98f2a9.PNG) | <img width="320" alt="after" src="https://user-images.githubusercontent.com/600512/35325931-82cfece8-0138-11e8-8228-7cc0303c1142.png">

