### PR TITLE
fix: remove redundant `.git`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To compile Kotlin/Native use following steps:
 
 ```
 git clone https://github.com/JetBrains/kotlin-native.git
-cd kotlin-native.git
+cd kotlin-native
 ./gradlew dependencies:update
 # this may take around a hour
 ./gradlew dist distPlatformLibs


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- remove redundant `.git`

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
